### PR TITLE
Add META REFRESH tag for HTML-only redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,8 +16,9 @@
     </script>
 </head>
 <body>
-<p>You will be redirected to the documentation below in 5 seconds. Wait
-or click the link below</p>
+<p>You will be redirected to the documentation below in 5 seconds. Note
+that scaladoc documentation requires Javascript for use. Please enable
+Javascript then wait 5 seconds or click the link below.</p>
 <a href="latest/api">Go to the project documentation
 </a>
 </body>

--- a/index.html
+++ b/index.html
@@ -16,10 +16,11 @@
     </script>
 </head>
 <body>
-<p>You will be redirected to the documentation below in 5 seconds. Note
-that scaladoc documentation requires Javascript for use. Please enable
-Javascript then wait 5 seconds or click the link below.</p>
-<a href="latest/api">Go to the project documentation
-</a>
+    <noscript>
+        <p>
+            You will be redirected to the documentation below in 5 seconds. Note that scaladoc documentation requires Javascript for use. Please enable Javascript then wait 5 seconds or click the link below.
+        </p>
+    </noscript>
+    <a href="latest/api">Go to the project documentation</a>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Project Documentation</title>
+	<meta http-equiv="refresh" content="5;URL='https://swoop-inc.github.io/scala-sugar/latest/api/'" />
     <script language="JavaScript">
         <!--
         function doRedirect()
@@ -15,6 +16,8 @@
     </script>
 </head>
 <body>
+<p>You will be redirected to the documentation below in 5 seconds. Wait
+or click the link below</p>
 <a href="latest/api">Go to the project documentation
 </a>
 </body>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Project Documentation</title>
-	<meta http-equiv="refresh" content="5;URL='https://swoop-inc.github.io/scala-sugar/latest/api/'" />
+    <meta http-equiv="refresh" content="5;URL='https://swoop-inc.github.io/scala-sugar/latest/api/'" />
     <script language="JavaScript">
         <!--
         function doRedirect()


### PR DESCRIPTION
Support browsers that have javascript off via html refresh tags. And ask users to turn on JS so the documentation will work.
